### PR TITLE
Propose a new PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,8 @@
 
 > Link to Jira ticket if applicable
 > Describe the changes (even if there is a description in Jira)
-> Identify backwards incompatible changes; link to tickets/PRs that must merge or deploy first
+> Clarify the thinking behind significant design decisions, including new dependencies and secrets
+> Identify changes that are backwards incompatible or depend on other work; link to tickets/PRs that must merge or deploy first
 > Call out known issues, high risk areas, or future work to be done
 > Include guidance for reviewers if relevant
 
@@ -13,6 +14,7 @@
 > List the steps you took to test the change manually
 > Characterize the automatic test coverage
 > Provide screenshots or video if applicable
+> Link to Figma, specs, etc. if it would help to verify behavior
 
 ## Security
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,20 @@
 ## Change Summary
 
-> Description here
+> Link to Jira ticket if applicable
+> Describe the changes (even if there is a description in Jira)
+> Identify backwards incompatible changes; link to tickets/PRs that must merge or deploy first
+> Call out known issues, high risk areas, or future work to be done
+> Include guidance for reviewers if relevant
 
-## Type of change
-- [ ] Bug fix (fixes an issue)
-- [ ] New feature (adds functionality)
-- [ ] Refactor (changes code structure with same or similar functionality)
-- [ ] Libs update (Libs update with code change or with minor code change to get new version working)
+## How I know it works
 
-## Checklists
+- [ ] I reviewed the code myself before requesting another engineer's review
 
-### Development
+> List the steps you took to test the change manually
+> Characterize the automatic test coverage
+> Provide screenshots or video if applicable
 
-- [ ] Application changes have been tested thoroughly
-- [ ] Automated tests covering modified code pass
-- [ ] The README file is updated if needed
+## Security
 
-### Security
-
-- [ ] Security impact of change has been considered
-- [ ] New endpoints that should be protected have been registered in Auth services
-
-### Code review 
-
-- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
-- [ ] Changes have been reviewed by at least one other contributor
-- [ ] Pull request linked to task tracker where applicable
+> Describe the security impact of this change (or "no impact")
+> List or link to request to protect new private endpoints in Auth services, if applicable


### PR DESCRIPTION
PR templates can serve two purposes:
1. Help PR reviewers understand the changes that were made
2. Help PR authors ensure that their changes consider all important factors

I have not found the current PR template to be helpful with either one, because it does not provide much guidance, and its checklist items are often not relevant.

The change I'm proposing focuses on writing clear descriptions of changes and ensuring that PR authors have tested their changes.

I am curious to hear your feedback!