### PR TITLE
Adds "Estimated review effort" to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+Estimated review effort:
+
 ## Change Summary
 
 > Link to Jira ticket if applicable


### PR DESCRIPTION
Estimated review effort: tiny

## Change Summary

Addresses feedback from [this Slack thread](https://poweredbyash.slack.com/archives/C01CLLXBAR5/p1754661170034839?thread_ts=1754065441.413019&cid=C01CLLXBAR5) regarding the recent PR template updates. Namely, Ilya's feedback was that removing the "Type of change" section made it harder to determine if a PR could be reviewed quickly. So this PR adds a line for PR authors to call that out explicitly.

## How I know it works

It's just text.

## Security

No impact